### PR TITLE
Release v1.2.0

### DIFF
--- a/ios/now.xcodeproj/xcshareddata/xcschemes/now.xcscheme
+++ b/ios/now.xcodeproj/xcshareddata/xcschemes/now.xcscheme
@@ -70,7 +70,7 @@
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Release"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"

--- a/ios/now.xcodeproj/xcshareddata/xcschemes/now.xcscheme
+++ b/ios/now.xcodeproj/xcshareddata/xcschemes/now.xcscheme
@@ -70,7 +70,7 @@
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "now",
-	"version": "1.1.1",
-	"update": "2",
+	"version": "1.2.0",
+	"update": "1",
 	"private": true,
 	"scripts": {
 		"start": "node node_modules/react-native/local-cli/cli.js start",


### PR DESCRIPTION
This is a PR for the next major update `1.2.0` that will go through the stores.

## v1.2.0 TODO

- [ ] Properly handle unauthenticated state in Today widgets (#19)
- [ ] Cache latest state and display it on startup (#18). This will also make sure user is never stuck on splash screen in case of a network failure
- [ ] Refactor Settings screen (#12)
- [ ] Properly handle empty avatars (#30 / #16)
- [ ] Delete deployments
- [ ] An option to buy domain during aliasing. It appears according to [3.1.5 (a)](https://developer.apple.com/app-store/review/guidelines/#multiplatform-services) of Apple Review Guidelines that domain purchase should not trigger a rejection for not using iAP
- [ ] Scale management for deployments. Currently we display scale table in deployment details view but it'll be nice to have the ability to set scale rules from the phone directly
- [ ] Deploy stuff via the app using share extensions. This also needs to have an ability to set environment variables like [deploy.now.sh](https://deploy.now.sh) does
- [ ] [?] Should we also prompt aliasing after deployment is done?
- [ ] Fix background fetch on the Watch sometimes loosing usage which leads to a stale complication
- [ ] With iOS 12 right around the corner, support for Siri Shortcuts for accessing deployments and usage would be nice